### PR TITLE
fix(app): prevent status conversion on numeric responses

### DIFF
--- a/app-chatgpt.js
+++ b/app-chatgpt.js
@@ -82,7 +82,7 @@ app.options('*', async (req, res) => {
       validateStatus: () => true,
     });
     console.log(`Forwarding OPTIONS [chatgpt] request to: ${url} (${req.originalUrl})`);
-    res.status(getResponseStatus(response.status)).set(response.headers).send(response.data);
+    res.status(getResponseStatus(response.status)).set(response.headers).send(typeof response.data === 'number' ? String(response.data) : response.data);
   } catch (e) {
     const status = e.response?.status ?? 502;
     res.status(getResponseStatus(status)).set(e.response?.headers ?? {}).send(e.response?.data ?? 'Upstream error');
@@ -114,7 +114,7 @@ app.post('*', async (req, res) => {
       maxBodyLength: Infinity,
       validateStatus: () => true,
     });
-    res.status(getResponseStatus(response.status)).set(response.headers).send(response.data);
+    res.status(getResponseStatus(response.status)).set(response.headers).send(typeof response.data === 'number' ? String(response.data) : response.data);
   } catch (e) {
     const status = e.response?.status ?? 502;
     res.status(getResponseStatus(status)).set(e.response?.headers ?? {}).send(e.response?.data ?? 'Upstream error');
@@ -144,7 +144,7 @@ app.get("*", async (req, res) => {
       headers: forwardHeaders(req),
       validateStatus: () => true,
     });
-    res.status(getResponseStatus(response.status)).set(response.headers).send(response.data);
+    res.status(getResponseStatus(response.status)).set(response.headers).send(typeof response.data === 'number' ? String(response.data) : response.data);
   } catch (e) {
     const status = e.response?.status ?? 502;
     res.status(getResponseStatus(status)).set(e.response?.headers ?? {}).send(e.response?.data ?? 'Upstream error');

--- a/app-instagram.js
+++ b/app-instagram.js
@@ -34,7 +34,7 @@ app.post('*', async (req, res) => {
       maxBodyLength: Infinity,
       validateStatus: () => true,
     });
-    res.status(response.status).set(response.headers).send(response.data);
+    res.status(response.status).set(response.headers).send(typeof response.data === 'number' ? String(response.data) : response.data);
   } catch (e) {
     const status = e.response?.status ?? 502;
     res.status(status).send(e.response?.data ?? 'Upstream error');
@@ -59,7 +59,7 @@ app.get("*", async (req, res) => {
     if (!isRedirect && data && typeof data === 'object' && 'content' in data) {
       res.status(response.status).send(String(data.content));
     } else {
-      res.status(response.status).set(response.headers).send(data);
+      res.status(response.status).set(response.headers).send(typeof data === 'number' ? String(data) : data);
     }
   } catch (e) {
     const status = e.response?.status ?? 502;


### PR DESCRIPTION
When the `challenge` values sent by Meta are numeric, Express is attempting a numeric `send()`; resulting in an invalid HTTP statuses that cause 502.
Can be reproduced with:
```
curl -i \
  '{$ngrokURL}/API/ai-agent-builder/channels/webhook?hub.mode=subscribe&hub.verify_token=jotform-test&hub.challenge=1249673095' \
  -H 'ngrok-skip-browser-warning: true'
```

or any curl where the challenge is numeric.